### PR TITLE
LENS-35 - Hide the 'Signless Transactions' purple component from the main page

### DIFF
--- a/apps/web/src/components/Home/index.tsx
+++ b/apps/web/src/components/Home/index.tsx
@@ -3,6 +3,7 @@ import NewPost from '@components/Composer/Post/New';
 import ExploreFeed from '@components/Explore/Feed';
 import Footer from '@components/Shared/Footer';
 import { Mixpanel } from '@lib/mixpanel';
+import { IS_RELAYER_AVAILABLE } from 'data';
 import type { NextPage } from 'next';
 import { useEffect, useState } from 'react';
 import { useAppStore } from 'src/store/app';
@@ -46,7 +47,7 @@ const Home: NextPage = () => {
         <GridItemFour>
           {currentProfile ? (
             <>
-              <EnableDispatcher />
+              {IS_RELAYER_AVAILABLE && <EnableDispatcher />}
               <EnableMessages />
               <SetDefaultProfile />
               <SetProfile />


### PR DESCRIPTION
## What does this PR do?

### Before

<img width="1265" alt="image" src="https://user-images.githubusercontent.com/5815882/234049957-f9f88dc7-5cff-4792-8bf5-5cada6e9d583.png">

### After

<img width="1283" alt="image" src="https://user-images.githubusercontent.com/5815882/234049856-3100497a-ffbe-4b18-939f-7376d925e301.png">

## Related ticket

Fixes [LENS-35](https://consensyssoftware.atlassian.net/browse/LENS-35)

## Type of change

- [ ] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-35]: https://consensyssoftware.atlassian.net/browse/LENS-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ