### PR TITLE
LENS-34 - Hide 'Dispatcher' and 'Allowance' tabs from the Settings page

### DIFF
--- a/apps/web/src/components/Settings/Sidebar.tsx
+++ b/apps/web/src/components/Settings/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   UserIcon
 } from '@heroicons/react/outline';
 import { t, Trans } from '@lingui/macro';
+import { IS_RELAYER_AVAILABLE } from 'data';
 import type { Profile } from 'lens';
 import type { FC } from 'react';
 import { useAppStore } from 'src/store/app';
@@ -45,16 +46,24 @@ const SettingsSidebar: FC = () => {
             icon: <BookmarkIcon className="h-4 w-4" />,
             url: '/settings/interests'
           },
-          {
-            title: t`Dispatcher`,
-            icon: <FingerPrintIcon className="h-4 w-4" />,
-            url: '/settings/dispatcher'
-          },
-          {
-            title: t`Allowance`,
-            icon: <ShareIcon className="h-4 w-4" />,
-            url: '/settings/allowance'
-          },
+          ...(IS_RELAYER_AVAILABLE
+            ? [
+                {
+                  title: t`Dispatcher`,
+                  icon: <FingerPrintIcon className="h-4 w-4" />,
+                  url: '/settings/dispatcher'
+                }
+              ]
+            : []),
+          ...(IS_RELAYER_AVAILABLE
+            ? [
+                {
+                  title: t`Allowance`,
+                  icon: <ShareIcon className="h-4 w-4" />,
+                  url: '/settings/allowance'
+                }
+              ]
+            : []),
           {
             title: t`Cleanup`,
             icon: <SparklesIcon className="h-4 w-4" />,


### PR DESCRIPTION
## What does this PR do?

### Before

<img width="419" alt="image" src="https://user-images.githubusercontent.com/5815882/234053113-665dc7b7-0e07-44ae-a369-f34655e86ffc.png">

### After

<img width="424" alt="image" src="https://user-images.githubusercontent.com/5815882/234053078-ca3bcecc-f42d-434b-ac3d-96ba73c540f7.png">

## Related ticket

Fixes [LENS-34](https://consensyssoftware.atlassian.net/browse/LENS-34)

## Type of change

- [ ] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-34]: https://consensyssoftware.atlassian.net/browse/LENS-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ