### PR TITLE
LENS-32 - Change Rarible links (as it doesn't support Linea) into explorer links

### DIFF
--- a/apps/web/src/components/Nft/SingleNft.tsx
+++ b/apps/web/src/components/Nft/SingleNft.tsx
@@ -1,7 +1,8 @@
-import { RARIBLE_URL, STATIC_IMAGES_URL } from 'data/constants';
+import { IS_RARIBLE_AVAILABLE, LINEA_EXPLORER_URL, RARIBLE_URL, STATIC_IMAGES_URL } from 'data/constants';
 import type { Nft } from 'lens';
 import sanitizeDStorageUrl from 'lib/sanitizeDStorageUrl';
 import type { FC } from 'react';
+import { useMemo } from 'react';
 import { CHAIN_ID } from 'src/constants';
 import { Card } from 'ui';
 
@@ -11,18 +12,24 @@ interface SingleNftProps {
 }
 
 const SingleNft: FC<SingleNftProps> = ({ nft, linkToDetail = true }) => {
-  const nftURL = linkToDetail
-    ? `${RARIBLE_URL}/token/${nft.chainId === CHAIN_ID ? 'polygon/' : ''}${nft.contractAddress}:${
-        nft.tokenId
-      }`.toLowerCase()
-    : undefined;
+  const nftUrl = useMemo(() => {
+    if (linkToDetail) {
+      if (IS_RARIBLE_AVAILABLE) {
+        return `${RARIBLE_URL}/token/${nft.chainId === CHAIN_ID ? 'linea/' : ''}${nft.contractAddress}:${
+          nft.tokenId
+        }`.toLowerCase();
+      } else {
+        return `${LINEA_EXPLORER_URL}/token/${nft.contractAddress}/${nft.tokenId}`.toLowerCase();
+      }
+    }
+  }, [linkToDetail, nft.chainId, nft.tokenId, nft.contractAddress]);
 
   return (
     <Card>
       {nft?.originalContent?.animatedUrl ? (
         <div className="divider h-52 sm:h-80 sm:rounded-t-[10px]">
           {nft?.originalContent?.animatedUrl?.includes('.gltf') ? (
-            <a href={nftURL} target="_blank" rel="noreferrer noopener">
+            <a href={nftUrl} target="_blank" rel="noreferrer noopener">
               <div
                 style={{
                   backgroundImage: `url(${`${STATIC_IMAGES_URL}/placeholder.webp`})`,
@@ -41,7 +48,7 @@ const SingleNft: FC<SingleNftProps> = ({ nft, linkToDetail = true }) => {
           )}
         </div>
       ) : (
-        <a href={nftURL} target="_blank" rel="noreferrer noopener">
+        <a href={nftUrl} target="_blank" rel="noreferrer noopener">
           <div
             className="divider h-52 sm:h-80 sm:rounded-t-[10px]"
             style={{
@@ -60,7 +67,7 @@ const SingleNft: FC<SingleNftProps> = ({ nft, linkToDetail = true }) => {
       <div className="space-y-1 p-5">
         {nft.collectionName && <div className="lt-text-gray-500 truncate text-sm">{nft.collectionName}</div>}
         <div className="truncate">
-          <a className="font-bold" href={nftURL} target="_blank" rel="noreferrer noopener">
+          <a className="font-bold" href={nftUrl} target="_blank" rel="noreferrer noopener">
             {nft.name ? nft.name : `#${nft.tokenId}`}
           </a>
         </div>

--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -15,6 +15,7 @@ export const LENS_PERIPHERY = getEnvConfig().lensPeripheryAddress;
 export const DEFAULT_COLLECT_TOKEN = getEnvConfig().defaultCollectToken;
 export const LIT_PROTOCOL_ENVIRONMENT = getEnvConfig().litProtocolEnvironment;
 export const IS_RELAYER_AVAILABLE = getEnvConfig().isRelayerAvailable;
+export const IS_RARIBLE_AVAILABLE = getEnvConfig().isRaribleAvailable;
 export const LENS_PROFILE_CREATOR = '0x923e7786176Ef21d0B31645fB1353b1392Dd0e40';
 export const LENS_PROFILE_CREATOR_ABI = [
   {
@@ -99,6 +100,9 @@ export const MIXPANEL_ENABLED = MIXPANEL_TOKEN && IS_PRODUCTION;
 export const STATIC_ASSETS_URL = 'https://static-assets.lenster.xyz';
 export const STATIC_IMAGES_URL = `${STATIC_ASSETS_URL}/images`;
 export const POLYGONSCAN_URL = IS_MAINNET ? 'https://polygonscan.com' : 'https://mumbai.polygonscan.com';
+export const LINEA_EXPLORER_URL = IS_MAINNET
+  ? 'https://explorer.linea.build'
+  : 'https://explorer.goerli.linea.build';
 export const RARIBLE_URL = IS_MAINNET ? 'https://rarible.com' : 'https://testnet.rarible.com';
 export const IPFS_GATEWAY = 'https://gateway.ipfscdn.io/ipfs/';
 export const ARWEAVE_GATEWAY = 'https://arweave.net/';

--- a/packages/data/utils/getEnvConfig.ts
+++ b/packages/data/utils/getEnvConfig.ts
@@ -10,6 +10,7 @@ const getEnvConfig = (): {
   UpdateOwnableFeeCollectModuleAddress: `0x${string}`;
   litProtocolEnvironment: string;
   isRelayerAvailable: boolean;
+  isRaribleAvailable: boolean;
 } => {
   switch (LENS_NETWORK) {
     case 'mainnet':
@@ -20,7 +21,8 @@ const getEnvConfig = (): {
         defaultCollectToken: MainnetContracts.DefaultToken,
         UpdateOwnableFeeCollectModuleAddress: MainnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'polygon',
-        isRelayerAvailable: false
+        isRelayerAvailable: false,
+        isRaribleAvailable: false
       };
     case 'testnet':
       return {
@@ -30,7 +32,8 @@ const getEnvConfig = (): {
         defaultCollectToken: TestnetContracts.DefaultToken,
         UpdateOwnableFeeCollectModuleAddress: TestnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'mumbai',
-        isRelayerAvailable: false
+        isRelayerAvailable: false,
+        isRaribleAvailable: false
       };
     case 'staging':
       return {
@@ -40,7 +43,8 @@ const getEnvConfig = (): {
         defaultCollectToken: TestnetContracts.DefaultToken,
         UpdateOwnableFeeCollectModuleAddress: TestnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'mumbai',
-        isRelayerAvailable: false
+        isRelayerAvailable: false,
+        isRaribleAvailable: false
       };
     case 'sandbox':
       return {
@@ -50,7 +54,8 @@ const getEnvConfig = (): {
         defaultCollectToken: TestnetContracts.DefaultToken,
         UpdateOwnableFeeCollectModuleAddress: TestnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'mumbai-sandbox',
-        isRelayerAvailable: false
+        isRelayerAvailable: false,
+        isRaribleAvailable: false
       };
     case 'staging-sandbox':
       return {
@@ -60,7 +65,8 @@ const getEnvConfig = (): {
         defaultCollectToken: TestnetContracts.DefaultToken,
         UpdateOwnableFeeCollectModuleAddress: TestnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'mumbai-sandbox',
-        isRelayerAvailable: false
+        isRelayerAvailable: false,
+        isRaribleAvailable: false
       };
     default:
       return {
@@ -70,7 +76,8 @@ const getEnvConfig = (): {
         defaultCollectToken: MainnetContracts.DefaultToken,
         UpdateOwnableFeeCollectModuleAddress: MainnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'polygon',
-        isRelayerAvailable: false
+        isRelayerAvailable: false,
+        isRaribleAvailable: false
       };
   }
 };


### PR DESCRIPTION
## What does this PR do?

If Rarible is available on Linea testnet => NFT links to Rarible
If Rarible is not available on Linea testnet => NFT links to Linea explorer

## Related ticket

Fixes [LENS-32](https://consensyssoftware.atlassian.net/browse/LENS-32)

## Type of change

- [ ] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [X] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-32]: https://consensyssoftware.atlassian.net/browse/LENS-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ