### PR TITLE
LENS-28 - Switch all explorer links to Linea explorer

### DIFF
--- a/apps/web/src/components/Notification/WalletProfile.tsx
+++ b/apps/web/src/components/Notification/WalletProfile.tsx
@@ -1,4 +1,4 @@
-import { POLYGONSCAN_URL } from 'data/constants';
+import { LINEA_EXPLORER_URL } from 'data/constants';
 import type { Wallet } from 'lens';
 import formatAddress from 'lib/formatAddress';
 import getStampFyiURL from 'lib/getStampFyiURL';
@@ -12,7 +12,7 @@ interface NotificationWalletProfileProps {
 
 export const NotificationWalletProfileAvatar: FC<NotificationWalletProfileProps> = ({ wallet }) => {
   return (
-    <a href={`${POLYGONSCAN_URL}/address/${wallet?.address}`} target="_blank" rel="noreferrer noopener">
+    <a href={`${LINEA_EXPLORER_URL}/address/${wallet?.address}`} target="_blank" rel="noreferrer noopener">
       <Image
         onError={({ currentTarget }) => {
           currentTarget.src = getStampFyiURL(wallet?.address);
@@ -31,7 +31,7 @@ export const NotificationWalletProfileName: FC<NotificationWalletProfileProps> =
   return (
     <a
       className="inline-flex items-center space-x-1 font-bold"
-      href={`${POLYGONSCAN_URL}/address/${wallet?.address}`}
+      href={`${LINEA_EXPLORER_URL}/address/${wallet?.address}`}
       target="_blank"
       rel="noreferrer noopener"
     >

--- a/apps/web/src/components/Publication/Actions/Collect/CollectModule.tsx
+++ b/apps/web/src/components/Publication/Actions/Collect/CollectModule.tsx
@@ -22,7 +22,7 @@ import splitSignature from '@lib/splitSignature';
 import { t, Trans } from '@lingui/macro';
 import { useQuery } from '@tanstack/react-query';
 import { LensHub, UpdateOwnableFeeCollectModule } from 'abis';
-import { IS_RELAYER_AVAILABLE, LENSHUB_PROXY, POLYGONSCAN_URL } from 'data/constants';
+import { IS_RELAYER_AVAILABLE, LENSHUB_PROXY, LINEA_EXPLORER_URL } from 'data/constants';
 import Errors from 'data/errors';
 import getEnvConfig from 'data/utils/getEnvConfig';
 import dayjs from 'dayjs';
@@ -405,7 +405,7 @@ const CollectModule: FC<CollectModuleProps> = ({ count, setCount, publication, e
                   <Trans>Token:</Trans>
                 </span>
                 <a
-                  href={`${POLYGONSCAN_URL}/token/${data?.publication?.collectNftAddress}`}
+                  href={`${LINEA_EXPLORER_URL}/token/${data?.publication?.collectNftAddress}`}
                   target="_blank"
                   className="font-bold text-gray-600"
                   rel="noreferrer noopener"

--- a/apps/web/src/components/Publication/Actions/Collect/Splits.tsx
+++ b/apps/web/src/components/Publication/Actions/Collect/Splits.tsx
@@ -1,6 +1,6 @@
 import Slug from '@components/Shared/Slug';
 import { Trans } from '@lingui/macro';
-import { POLYGONSCAN_URL } from 'data/constants';
+import { LINEA_EXPLORER_URL } from 'data/constants';
 import type { Profile, RecipientDataOutput } from 'lens';
 import { useProfilesQuery } from 'lens';
 import formatAddress from 'lib/formatAddress';
@@ -59,7 +59,7 @@ const Splits: FC<SplitsProps> = ({ recipients }) => {
                       <Slug slug={formatHandle(profile?.handle)} prefix="@" />
                     </Link>
                   ) : (
-                    <a href={`${POLYGONSCAN_URL}/address/${address}`} target="_blank" rel="noreferrer">
+                    <a href={`${LINEA_EXPLORER_URL}/address/${address}`} target="_blank" rel="noreferrer">
                       {formatAddress(address, 6)}
                     </a>
                   )}

--- a/apps/web/src/components/Publication/DecryptedPublicationBody.tsx
+++ b/apps/web/src/components/Publication/DecryptedPublicationBody.tsx
@@ -22,7 +22,7 @@ import { Mixpanel } from '@lib/mixpanel';
 import { t, Trans } from '@lingui/macro';
 import axios from 'axios';
 import clsx from 'clsx';
-import { LIT_PROTOCOL_ENVIRONMENT, POLYGONSCAN_URL, RARIBLE_URL } from 'data/constants';
+import { LINEA_EXPLORER_URL, LIT_PROTOCOL_ENVIRONMENT, RARIBLE_URL } from 'data/constants';
 import type { Publication, PublicationMetadataV2Input } from 'lens';
 import { DecryptFailReason, useCanDecryptStatusQuery } from 'lens';
 import formatHandle from 'lib/formatHandle';
@@ -232,7 +232,7 @@ const DecryptedPublicationBody: FC<DecryptedPublicationBodyProps> = ({ encrypted
             <DecryptMessage icon={<DatabaseIcon className="h-4 w-4" />}>
               You need{' '}
               <a
-                href={`${POLYGONSCAN_URL}/token/${tokenCondition.contractAddress}`}
+                href={`${LINEA_EXPLORER_URL}/token/${tokenCondition.contractAddress}`}
                 className="font-bold underline"
                 onClick={() => Mixpanel.track(PUBLICATION.TOKEN_GATED.CHECKLIST_NAVIGATED_TO_TOKEN)}
                 target="_blank"

--- a/apps/web/src/components/Publication/OnchainMeta.tsx
+++ b/apps/web/src/components/Publication/OnchainMeta.tsx
@@ -1,6 +1,6 @@
 import { ExternalLinkIcon } from '@heroicons/react/outline';
 import { t } from '@lingui/macro';
-import { IPFS_GATEWAY, POLYGONSCAN_URL } from 'data/constants';
+import { IPFS_GATEWAY, LINEA_EXPLORER_URL } from 'data/constants';
 import type { Publication } from 'lens';
 import type { FC } from 'react';
 import { Card } from 'ui';
@@ -53,7 +53,7 @@ const OnchainMeta: FC<OnchainMetaProps> = ({ publication }) => {
         {collectNftAddress ? (
           <Meta
             name={t`NFT ADDRESS`}
-            uri={`${POLYGONSCAN_URL}/token/${collectNftAddress}`}
+            uri={`${LINEA_EXPLORER_URL}/token/${collectNftAddress}`}
             hash={collectNftAddress}
           />
         ) : null}

--- a/apps/web/src/components/Settings/Allowance/Module.tsx
+++ b/apps/web/src/components/Settings/Allowance/Module.tsx
@@ -1,6 +1,6 @@
 import GetModuleIcon from '@components/utils/GetModuleIcon';
 import { getModule } from '@lib/getModule';
-import { POLYGONSCAN_URL } from 'data/constants';
+import { LINEA_EXPLORER_URL } from 'data/constants';
 import type { ApprovedAllowanceAmount } from 'lens';
 import type { FC } from 'react';
 import { useState } from 'react';
@@ -25,7 +25,7 @@ const Module: FC<ModuleProps> = ({ module }) => {
           <div className="whitespace-nowrap font-bold">{getModule(module?.module).name}</div>
         </div>
         <a
-          href={`${POLYGONSCAN_URL}/address/${module?.contractAddress}`}
+          href={`${LINEA_EXPLORER_URL}/address/${module?.contractAddress}`}
           className="lt-text-gray-500 truncate text-sm"
           target="_blank"
           rel="noreferrer noopener"

--- a/apps/web/src/components/Shared/IndexStatus.tsx
+++ b/apps/web/src/components/Shared/IndexStatus.tsx
@@ -1,7 +1,7 @@
 import { CheckCircleIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/macro';
 import clsx from 'clsx';
-import { POLYGONSCAN_URL } from 'data/constants';
+import { LINEA_EXPLORER_URL } from 'data/constants';
 import { useHasTxHashBeenIndexedQuery } from 'lens';
 import type { FC } from 'react';
 import { useState } from 'react';
@@ -35,7 +35,7 @@ const IndexStatus: FC<IndexStatusProps> = ({ type = 'Transaction', txHash, reloa
   return (
     <a
       className={clsx({ hidden: hide }, 'ml-auto text-sm font-medium')}
-      href={`${POLYGONSCAN_URL}/tx/${txHash}`}
+      href={`${LINEA_EXPLORER_URL}/tx/${txHash}`}
       target="_blank"
       rel="noreferrer noopener"
     >

--- a/apps/web/src/components/Shared/SuperFollow/FollowModule.tsx
+++ b/apps/web/src/components/Shared/SuperFollow/FollowModule.tsx
@@ -5,7 +5,7 @@ import onError from '@lib/onError';
 import splitSignature from '@lib/splitSignature';
 import { t, Trans } from '@lingui/macro';
 import { LensHub } from 'abis';
-import { LENSHUB_PROXY, POLYGONSCAN_URL } from 'data/constants';
+import { LENSHUB_PROXY, LINEA_EXPLORER_URL } from 'data/constants';
 import Errors from 'data/errors';
 import type { ApprovedAllowanceAmount, Profile } from 'lens';
 import {
@@ -185,7 +185,7 @@ const FollowModule: FC<FollowModuleProps> = ({ profile, setFollowing, setShowFol
             <Trans>Recipient:</Trans>
           </span>
           <a
-            href={`${POLYGONSCAN_URL}/address/${followModule?.recipient}`}
+            href={`${LINEA_EXPLORER_URL}/address/${followModule?.recipient}`}
             target="_blank"
             className="font-bold text-gray-600"
             rel="noreferrer noopener"

--- a/apps/web/src/components/Shared/WalletProfile.tsx
+++ b/apps/web/src/components/Shared/WalletProfile.tsx
@@ -1,5 +1,5 @@
 import { ExternalLinkIcon } from '@heroicons/react/outline';
-import { POLYGONSCAN_URL } from 'data/constants';
+import { LINEA_EXPLORER_URL } from 'data/constants';
 import type { Wallet } from 'lens';
 import formatAddress from 'lib/formatAddress';
 import getStampFyiURL from 'lib/getStampFyiURL';
@@ -17,7 +17,7 @@ const WalletProfile: FC<WalletProfileProps> = ({ wallet }) => {
   return (
     <div className="flex items-center justify-between">
       <a
-        href={`${POLYGONSCAN_URL}/address/${wallet?.address}`}
+        href={`${LINEA_EXPLORER_URL}/address/${wallet?.address}`}
         className="flex items-center space-x-3"
         target="_blank"
         rel="noreferrer noopener"


### PR DESCRIPTION
## What does this PR do?

All links to Polygonscan explorer are replaced by Linea explorer links.

## Related ticket

Fixes [LENS-28](https://consensyssoftware.atlassian.net/browse/LENS-28)

## Type of change

- [X] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-28]: https://consensyssoftware.atlassian.net/browse/LENS-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ