### PR TITLE
LENS-69 - Hide the "NFT" tab on profile as long as Moralis is not available

### DIFF
--- a/apps/prerender/src/components/Profile.tsx
+++ b/apps/prerender/src/components/Profile.tsx
@@ -1,4 +1,4 @@
-import { AVATAR, USER_CONTENT_URL } from 'data/constants';
+import { AVATAR, IS_MORALIS_AVAILABLE, USER_CONTENT_URL } from 'data/constants';
 import type { MediaSet, NftImage, Publication } from 'lens';
 import { Profile } from 'lens';
 import formatHandle from 'lib/formatHandle';
@@ -106,9 +106,11 @@ const Profile: FC<ProfileProps> = ({ profile, publications }) => {
           <div>
             <a href={`${BASE_URL}/u/${formatHandle(profile.handle)}?type=collects`}>Collected</a>
           </div>
-          <div>
-            <a href={`${BASE_URL}/u/${formatHandle(profile.handle)}?type=nft`}>NFTs</a>
-          </div>
+          {IS_MORALIS_AVAILABLE && (
+            <div>
+              <a href={`${BASE_URL}/u/${formatHandle(profile.handle)}?type=nft`}>NFTs</a>
+            </div>
+          )}
         </nav>
         <hr />
       </header>

--- a/apps/web/src/components/Profile/FeedType.tsx
+++ b/apps/web/src/components/Profile/FeedType.tsx
@@ -7,6 +7,7 @@ import {
 } from '@heroicons/react/outline';
 import { Mixpanel } from '@lib/mixpanel';
 import { t } from '@lingui/macro';
+import { IS_MORALIS_AVAILABLE } from 'data';
 import type { Dispatch, FC } from 'react';
 import { ProfileFeedType } from 'src/enums';
 import { PROFILE } from 'src/tracking';
@@ -58,13 +59,15 @@ const FeedType: FC<FeedTypeProps> = ({ setFeedType, feedType }) => {
           type={ProfileFeedType.Collects.toLowerCase()}
           onClick={() => switchTab(ProfileFeedType.Collects)}
         />
-        <TabButton
-          name={t`NFTs`}
-          icon={<PhotographIcon className="h-4 w-4" />}
-          active={feedType === ProfileFeedType.Nft}
-          type={ProfileFeedType.Nft.toLowerCase()}
-          onClick={() => switchTab(ProfileFeedType.Nft)}
-        />
+        {IS_MORALIS_AVAILABLE && (
+          <TabButton
+            name={t`NFTs`}
+            icon={<PhotographIcon className="h-4 w-4" />}
+            active={feedType === ProfileFeedType.Nft}
+            type={ProfileFeedType.Nft.toLowerCase()}
+            onClick={() => switchTab(ProfileFeedType.Nft)}
+          />
+        )}
       </div>
       <div>{feedType === ProfileFeedType.Media && <MediaFilter />}</div>
     </div>

--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_COLLECT_TOKEN = getEnvConfig().defaultCollectToken;
 export const LIT_PROTOCOL_ENVIRONMENT = getEnvConfig().litProtocolEnvironment;
 export const IS_RELAYER_AVAILABLE = getEnvConfig().isRelayerAvailable;
 export const IS_RARIBLE_AVAILABLE = getEnvConfig().isRaribleAvailable;
+export const IS_MORALIS_AVAILABLE = getEnvConfig().isMoralisAvailable;
 export const LENS_PROFILE_CREATOR = '0x923e7786176Ef21d0B31645fB1353b1392Dd0e40';
 export const LENS_PROFILE_CREATOR_ABI = [
   {

--- a/packages/data/utils/getEnvConfig.ts
+++ b/packages/data/utils/getEnvConfig.ts
@@ -11,6 +11,7 @@ const getEnvConfig = (): {
   litProtocolEnvironment: string;
   isRelayerAvailable: boolean;
   isRaribleAvailable: boolean;
+  isMoralisAvailable: boolean;
 } => {
   switch (LENS_NETWORK) {
     case 'mainnet':
@@ -22,7 +23,8 @@ const getEnvConfig = (): {
         UpdateOwnableFeeCollectModuleAddress: MainnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'polygon',
         isRelayerAvailable: false,
-        isRaribleAvailable: false
+        isRaribleAvailable: false,
+        isMoralisAvailable: false
       };
     case 'testnet':
       return {
@@ -33,7 +35,8 @@ const getEnvConfig = (): {
         UpdateOwnableFeeCollectModuleAddress: TestnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'mumbai',
         isRelayerAvailable: false,
-        isRaribleAvailable: false
+        isRaribleAvailable: false,
+        isMoralisAvailable: false
       };
     case 'staging':
       return {
@@ -44,7 +47,8 @@ const getEnvConfig = (): {
         UpdateOwnableFeeCollectModuleAddress: TestnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'mumbai',
         isRelayerAvailable: false,
-        isRaribleAvailable: false
+        isRaribleAvailable: false,
+        isMoralisAvailable: false
       };
     case 'sandbox':
       return {
@@ -55,7 +59,8 @@ const getEnvConfig = (): {
         UpdateOwnableFeeCollectModuleAddress: TestnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'mumbai-sandbox',
         isRelayerAvailable: false,
-        isRaribleAvailable: false
+        isRaribleAvailable: false,
+        isMoralisAvailable: false
       };
     case 'staging-sandbox':
       return {
@@ -66,7 +71,8 @@ const getEnvConfig = (): {
         UpdateOwnableFeeCollectModuleAddress: TestnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'mumbai-sandbox',
         isRelayerAvailable: false,
-        isRaribleAvailable: false
+        isRaribleAvailable: false,
+        isMoralisAvailable: false
       };
     default:
       return {
@@ -77,7 +83,8 @@ const getEnvConfig = (): {
         UpdateOwnableFeeCollectModuleAddress: MainnetContracts.UpdateOwnableFeeCollectModule,
         litProtocolEnvironment: 'polygon',
         isRelayerAvailable: false,
-        isRaribleAvailable: false
+        isRaribleAvailable: false,
+        isMoralisAvailable: false
       };
   }
 };


### PR DESCRIPTION
## What does this PR do?

Hides the `NFTs` tab on the Profile page, as long as Moralis is not available on Linea testnet

## Related ticket

Fixes [LENS-69](https://consensyssoftware.atlassian.net/browse/LENS-69)

## Type of change

- [ ] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-69]: https://consensyssoftware.atlassian.net/browse/LENS-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ