### PR TITLE
LENS-56 - Hide the "Access Management" feature (who can view a publication)

### DIFF
--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -25,6 +25,7 @@ import {
   ALLOWED_IMAGE_TYPES,
   ALLOWED_VIDEO_TYPES,
   APP_NAME,
+  IS_LIT_AVAILABLE,
   LENSHUB_PROXY,
   LIT_PROTOCOL_ENVIRONMENT
 } from 'data/constants';
@@ -475,7 +476,7 @@ const NewPublication: FC<NewPublicationProps> = ({ publication }) => {
         appId: APP_NAME
       };
 
-      let arweaveId = null;
+      let arweaveId;
       if (restricted) {
         arweaveId = await createTokenGatedMetadata(metadata);
       } else {
@@ -491,7 +492,7 @@ const NewPublication: FC<NewPublicationProps> = ({ publication }) => {
         collectModule: payload,
         referenceModule:
           selectedReferenceModule === ReferenceModules.FollowerOnlyReferenceModule
-            ? { followerOnlyReferenceModule: onlyFollowers ? true : false }
+            ? { followerOnlyReferenceModule: onlyFollowers }
             : {
                 degreesOfSeparationReferenceModule: {
                   commentsRestricted: true,
@@ -548,7 +549,7 @@ const NewPublication: FC<NewPublicationProps> = ({ publication }) => {
           <Giphy setGifAttachment={(gif: IGif) => setGifAttachment(gif)} />
           <CollectSettings />
           <ReferenceSettings />
-          <AccessSettings />
+          {IS_LIT_AVAILABLE && <AccessSettings />}
         </div>
         <div className="ml-auto pt-2 sm:pt-0">
           <Button

--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_COLLECT_TOKEN = getEnvConfig().defaultCollectToken;
 export const LIT_PROTOCOL_ENVIRONMENT = getEnvConfig().litProtocolEnvironment;
 export const IS_RELAYER_AVAILABLE = getEnvConfig().isRelayerAvailable;
 export const IS_RARIBLE_AVAILABLE = getEnvConfig().isRaribleAvailable;
+export const IS_LIT_AVAILABLE = getEnvConfig().isLitAvailable;
 export const IS_MORALIS_AVAILABLE = getEnvConfig().isMoralisAvailable;
 export const LENS_PROFILE_CREATOR = '0x923e7786176Ef21d0B31645fB1353b1392Dd0e40';
 export const LENS_PROFILE_CREATOR_ABI = [

--- a/packages/data/utils/getEnvConfig.ts
+++ b/packages/data/utils/getEnvConfig.ts
@@ -11,6 +11,7 @@ const getEnvConfig = (): {
   litProtocolEnvironment: string;
   isRelayerAvailable: boolean;
   isRaribleAvailable: boolean;
+  isLitAvailable: boolean;
   isMoralisAvailable: boolean;
 } => {
   switch (LENS_NETWORK) {
@@ -24,6 +25,7 @@ const getEnvConfig = (): {
         litProtocolEnvironment: 'polygon',
         isRelayerAvailable: false,
         isRaribleAvailable: false,
+        isLitAvailable: false,
         isMoralisAvailable: false
       };
     case 'testnet':
@@ -36,6 +38,7 @@ const getEnvConfig = (): {
         litProtocolEnvironment: 'mumbai',
         isRelayerAvailable: false,
         isRaribleAvailable: false,
+        isLitAvailable: false,
         isMoralisAvailable: false
       };
     case 'staging':
@@ -48,6 +51,7 @@ const getEnvConfig = (): {
         litProtocolEnvironment: 'mumbai',
         isRelayerAvailable: false,
         isRaribleAvailable: false,
+        isLitAvailable: false,
         isMoralisAvailable: false
       };
     case 'sandbox':
@@ -60,6 +64,7 @@ const getEnvConfig = (): {
         litProtocolEnvironment: 'mumbai-sandbox',
         isRelayerAvailable: false,
         isRaribleAvailable: false,
+        isLitAvailable: false,
         isMoralisAvailable: false
       };
     case 'staging-sandbox':
@@ -72,6 +77,7 @@ const getEnvConfig = (): {
         litProtocolEnvironment: 'mumbai-sandbox',
         isRelayerAvailable: false,
         isRaribleAvailable: false,
+        isLitAvailable: false,
         isMoralisAvailable: false
       };
     default:
@@ -84,6 +90,7 @@ const getEnvConfig = (): {
         litProtocolEnvironment: 'polygon',
         isRelayerAvailable: false,
         isRaribleAvailable: false,
+        isLitAvailable: false,
         isMoralisAvailable: false
       };
   }


### PR DESCRIPTION
## What does this PR do?

Hides the "access management" button on the publication creation modal as long as Lit Protocol is not deployed on the Linea testnet.

## Related ticket

Fixes [LENS-56](https://consensyssoftware.atlassian.net/browse/LENS-56)

## Type of change

- [ ] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-56]: https://consensyssoftware.atlassian.net/browse/LENS-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ