### PR TITLE
LENS-68 - Collect - "Set multiple recipients for the collect fee" not available

### DIFF
--- a/apps/web/src/components/Settings/Allowance/Allowance.tsx
+++ b/apps/web/src/components/Settings/Allowance/Allowance.tsx
@@ -13,7 +13,8 @@ const Allowance: FC<AllowanceProps> = ({ allowance }) => {
     <div className="space-y-4 p-5">
       {allowance?.approvedModuleAllowanceAmount?.map((item: ApprovedAllowanceAmount) =>
         item?.module === CollectModules.RevertCollectModule ||
-        item?.module === CollectModules.FreeCollectModule ? (
+        item?.module === CollectModules.FreeCollectModule ||
+        item?.module === CollectModules.MultirecipientFeeCollectModule ? (
           ''
         ) : (
           <Module key={item?.contractAddress} module={item} />


### PR DESCRIPTION
## What does this PR do?

Hides the `MutlirecipientFeeCollect` module as the contract is not deployed on Linea

## Related ticket

Fixes [LENS-68](https://consensyssoftware.atlassian.net/browse/LENS-68)

## Type of change

- [X] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-68]: https://consensyssoftware.atlassian.net/browse/LENS-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ