### PR TITLE
LENS-90 - Profile settings: display handle as name before it's set

### DIFF
--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -7,7 +7,7 @@ import uploadToArweave from '@lib/uploadToArweave';
 import uploadToIPFS from '@lib/uploadToIPFS';
 import { t, Trans } from '@lingui/macro';
 import { LensPeriphery } from 'abis';
-import { APP_NAME, COVER, LENS_PERIPHERY, URL_REGEX } from 'data/constants';
+import { APP_NAME, COVER, HANDLE_SUFFIX, LENS_PERIPHERY, URL_REGEX } from 'data/constants';
 import Errors from 'data/errors';
 import type { CreatePublicSetProfileMetadataUriRequest, MediaSet, Profile } from 'lens';
 import {
@@ -135,7 +135,7 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
   const form = useZodForm({
     schema: editProfileSchema,
     defaultValues: {
-      name: profile?.name ?? '',
+      name: profile?.name ?? currentProfile?.handle?.replace(HANDLE_SUFFIX, ''),
       location: getProfileAttribute(profile?.attributes, 'location'),
       website: getProfileAttribute(profile?.attributes, 'website'),
       twitter: getProfileAttribute(profile?.attributes, 'twitter')?.replace(


### PR DESCRIPTION
## What does this PR do?

Displays the handle instead of a placeholder name on the profile settings page as long as the name is not set yet.

## Related ticket

Fixes [LENS-90](https://consensyssoftware.atlassian.net/browse/LENS-90)

## Type of change

- [X] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-90]: https://consensyssoftware.atlassian.net/browse/LENS-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ