### PR TITLE
LENS-98 - Change reference to LensHub in MockProfileCreationProxy

### DIFF
--- a/apps/web/packages/data/constants.ts
+++ b/apps/web/packages/data/constants.ts
@@ -17,7 +17,7 @@ export const LIT_PROTOCOL_ENVIRONMENT = getEnvConfig().litProtocolEnvironment;
 export const IS_RELAYER_AVAILABLE = getEnvConfig().isRelayerAvailable;
 export const IS_RARIBLE_AVAILABLE = getEnvConfig().isRaribleAvailable;
 export const IS_LIT_AVAILABLE = getEnvConfig().isLitAvailable;
-export const LENS_PROFILE_CREATOR = '0x513405570f239a838f613CbE509c86455b0B6E8C';
+export const LENS_PROFILE_CREATOR = '0xfA91DD7A9CBbBC48a85b42745d9394c3938E90bE';
 export const LENS_PROFILE_CREATOR_ABI = [
   {
     inputs: [

--- a/blockchain/tasks/MockProfileCreationProxy.ts
+++ b/blockchain/tasks/MockProfileCreationProxy.ts
@@ -8,8 +8,8 @@ async function main() {
     'MockProfileCreationProxy'
   );
   const mockProfileCreationProxy = await mockProfileCreationProxy__factory.deploy(
-    '0x97F1d4aFE1A3D501731ca7993fE6E518F4FbcE76',
-    '0x117F113aEFb9AeD23d901C1fa02fDdaA1d20cCaB'
+    '0x28af365578586eD5Fd500A1Dc0a3E20Fc7b2Cffa', // LensHub
+    '0x117F113aEFb9AeD23d901C1fa02fDdaA1d20cCaB' // Linea ENS Resolver
   );
   await mockProfileCreationProxy.deployed();
   await mockProfileCreationProxy.deployTransaction.wait();

--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -17,7 +17,7 @@ export const LIT_PROTOCOL_ENVIRONMENT = getEnvConfig().litProtocolEnvironment;
 export const IS_RELAYER_AVAILABLE = getEnvConfig().isRelayerAvailable;
 export const IS_RARIBLE_AVAILABLE = getEnvConfig().isRaribleAvailable;
 export const IS_LIT_AVAILABLE = getEnvConfig().isLitAvailable;
-export const LENS_PROFILE_CREATOR = '0x513405570f239a838f613CbE509c86455b0B6E8C';
+export const LENS_PROFILE_CREATOR = '0xfA91DD7A9CBbBC48a85b42745d9394c3938E90bE';
 export const LENS_PROFILE_CREATOR_ABI = [
   {
     inputs: [


### PR DESCRIPTION
## What does this PR do?

Changes the reference to the `LensHub` contract in the `MockProfileCreationProxy`contract. This aims to add more rules for anyone to create a handle.

## Related ticket

Fixes [LENS-98](https://consensyssoftware.atlassian.net/browse/LENS-98)

## Type of change

- [ ] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-98]: https://consensyssoftware.atlassian.net/browse/LENS-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ