### PR TITLE
LENS-104 - Add a manual releaser pipeline to the CI

### DIFF
--- a/.github/workflows/releaser-dev.yaml
+++ b/.github/workflows/releaser-dev.yaml
@@ -1,0 +1,18 @@
+---
+name: Dev releaser
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.DEV_RELEASER_GH_TOKEN }}
+
+      - name: Run Dev release script
+        run: ./release-dev.sh

--- a/release-dev.sh
+++ b/release-dev.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+git config user.name github-actions[bot]
+git config user.email github-actions[bot]@users.noreply.github.com
+
+git checkout develop
+
+git merge --no-edit --no-ff main
+git push origin develop
+
+git checkout main
+git rebase develop
+git push origin main


### PR DESCRIPTION
## What does this PR do?

Adds a manually triggered pipeline to release new Docker images

## Related ticket

Fixes [LENS-104](https://consensyssoftware.atlassian.net/browse/LENS-104)

## Type of change

- [ ] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update


[LENS-104]: https://consensyssoftware.atlassian.net/browse/LENS-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ