### PR TITLE
LENS-107 - Add the ability to create posts from the profile page

### DIFF
--- a/apps/web/src/components/Profile/Details.tsx
+++ b/apps/web/src/components/Profile/Details.tsx
@@ -262,7 +262,7 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
                   alt="ENS Logo"
                 />
               }
-              dataTestId="profile-meta-ens"
+              dataTestId="profile-meta-linea-ens"
             >
               <a href={`${ENS_DOMAIN_URL}/${domain}`} target="_blank">
                 {domain}

--- a/apps/web/src/components/Profile/index.tsx
+++ b/apps/web/src/components/Profile/index.tsx
@@ -1,4 +1,5 @@
 import MetaTags from '@components/Common/MetaTags';
+import NewPost from '@components/Composer/Post/New';
 import NftFeed from '@components/Nft/NftFeed';
 import { Mixpanel } from '@lib/mixpanel';
 import { APP_NAME, STATIC_IMAGES_URL } from 'data/constants';
@@ -114,6 +115,7 @@ const ViewProfile: NextPage = () => {
         </GridItemFour>
         <GridItemEight className="space-y-5">
           <FeedType setFeedType={setFeedType} feedType={feedType} />
+          {currentProfile?.id === profile?.id ? <NewPost /> : null}
           {(feedType === ProfileFeedType.Feed ||
             feedType === ProfileFeedType.Replies ||
             feedType === ProfileFeedType.Media ||

--- a/tests/scripts/apps/web/profile.spec.ts
+++ b/tests/scripts/apps/web/profile.spec.ts
@@ -40,6 +40,10 @@ test.describe('Profile', async () => {
       await expect(page.getByTestId('profile-meta-ens')).toContainText('alainnicolas.eth');
     });
 
+    test('should have meta Linea ens', async ({ page }) => {
+      await expect(page.getByTestId('profile-meta-linea-ens')).toContainText('alain.lineatest.eth');
+    });
+
     test('should have meta website', async ({ page }) => {
       await expect(page.getByTestId('profile-meta-website')).toContainText('alainnicolas.fr');
     });


### PR DESCRIPTION
## What does this PR do?

1. Adds the post creation tool on the connected user's profile page
2. Better tests on the ENS domain(s) display

## Related ticket

Fixes [LENS-107](https://consensyssoftware.atlassian.net/browse/LENS-107)

## Type of change

- [ ] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [X] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-107]: https://consensyssoftware.atlassian.net/browse/LENS-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ