### PR TITLE
LENS-30 - Unfollow feature - Bypass the relayer

### DIFF
--- a/packages/lens/documents/queries/FollowerNftOwnedTokenIds.graphql
+++ b/packages/lens/documents/queries/FollowerNftOwnedTokenIds.graphql
@@ -1,0 +1,6 @@
+query FollowersNftOwnedTokenIds($request: FollowerNftOwnedTokenIdsRequest!) {
+    followerNftOwnedTokenIds(request: $request) {
+        followerNftAddress
+        tokensIds
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Re-activates the "Unfollow" feature, by calling the contract directly.

## Related ticket

Fixes [LENS-30](https://consensyssoftware.atlassian.net/browse/LENS-30)

## Type of change

- [X] Bug fix (non-breaking change, which fixes an issue)
- [ ] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-30]: https://consensyssoftware.atlassian.net/browse/LENS-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ