### PR TITLE
LENS-68 - Collect - "Set multiple recipients for the collect fee" not available

### DIFF
--- a/apps/web/src/components/Settings/Allowance/Allowance.tsx
+++ b/apps/web/src/components/Settings/Allowance/Allowance.tsx
@@ -14,7 +14,7 @@ const Allowance: FC<AllowanceProps> = ({ allowance }) => {
       {allowance?.approvedModuleAllowanceAmount?.map((item: ApprovedAllowanceAmount) =>
         item?.module === CollectModules.RevertCollectModule ||
         item?.module === CollectModules.FreeCollectModule ||
-        item?.module === CollectModules.MultirecipientFeeCollectModule ? (
+        item?.contractAddress === '0x000000000000000000000000000000000000dEaD' ? (
           ''
         ) : (
           <Module key={item?.contractAddress} module={item} />


### PR DESCRIPTION
## What does this PR do?

Displays the `MultirecipientFeeCollectModule` allowance as soon as it is set in the API

## Related ticket

Fixes [LENS-68](https://consensyssoftware.atlassian.net/browse/LENS-68)

## Type of change

- [ ] Bug fix (non-breaking change, which fixes an issue)
- [X] New feature (non-breaking change, which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


[LENS-68]: https://consensyssoftware.atlassian.net/browse/LENS-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ